### PR TITLE
Add work schedule options to Chrome extension

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,11 @@
+{
+  "manifest_version": 3,
+  "name": "Progression de la journée de travail",
+  "version": "1.0",
+  "description": "Affiche la progression de votre journée de travail.",
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "options_page": "options.html",
+  "permissions": ["storage"]
+}

--- a/extension/options.html
+++ b/extension/options.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Options d'horaire de travail</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    label { display: block; margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <h1>Horaire de travail</h1>
+  <form id="scheduleForm">
+    <label>Lundi : <input type="number" step="0.1" id="monday" /></label>
+    <label>Mardi : <input type="number" step="0.1" id="tuesday" /></label>
+    <label>Mercredi : <input type="number" step="0.1" id="wednesday" /></label>
+    <label>Jeudi : <input type="number" step="0.1" id="thursday" /></label>
+    <label>Vendredi : <input type="number" step="0.1" id="friday" /></label>
+    <button type="submit">Enregistrer</button>
+  </form>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,0 +1,28 @@
+async function getDefaultSchedule() {
+  const resp = await fetch(chrome.runtime.getURL('work_schedule.json'));
+  return resp.json();
+}
+
+function fillForm(schedule) {
+  ['monday','tuesday','wednesday','thursday','friday'].forEach(day => {
+    document.getElementById(day).value = schedule[day] ?? '';
+  });
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const defaults = await getDefaultSchedule();
+  chrome.storage.sync.get('workSchedule', (data) => {
+    const schedule = data.workSchedule || defaults;
+    fillForm(schedule);
+  });
+
+  document.getElementById('scheduleForm').addEventListener('submit', (e) => {
+    e.preventDefault();
+    const schedule = {};
+    ['monday','tuesday','wednesday','thursday','friday'].forEach(day => {
+      const val = parseFloat(document.getElementById(day).value);
+      if (!isNaN(val)) schedule[day] = val;
+    });
+    chrome.storage.sync.set({ workSchedule: schedule });
+  });
+});

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Progression de la journée de travail</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+  </style>
+</head>
+<body>
+  <div id="percentage">Chargement...</div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,40 @@
+async function getSchedule() {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get('workSchedule', async (data) => {
+      if (data.workSchedule) {
+        resolve(data.workSchedule);
+      } else {
+        const resp = await fetch(chrome.runtime.getURL('work_schedule.json'));
+        const json = await resp.json();
+        resolve(json);
+      }
+    });
+  });
+}
+
+async function update() {
+  const schedule = await getSchedule();
+  const dayNames = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
+  const now = new Date();
+  const day = dayNames[now.getDay()];
+  const hours = schedule[day];
+  const display = document.getElementById('percentage');
+  if (!hours) {
+    display.textContent = "Pas de travail aujourd'hui";
+    return;
+  }
+  const startHour = 9;
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), startHour, 0, 0);
+  const end = new Date(start.getTime() + hours * 3600 * 1000);
+  let percent;
+  if (now <= start) {
+    percent = 0;
+  } else if (now >= end) {
+    percent = 100;
+  } else {
+    percent = ((now - start) / (end - start) * 100);
+  }
+  display.textContent = percent.toFixed(2) + '% de votre journée de travail';
+}
+
+document.addEventListener('DOMContentLoaded', update);

--- a/extension/work_schedule.json
+++ b/extension/work_schedule.json
@@ -1,0 +1,7 @@
+{
+  "monday": 8,
+  "tuesday": 8,
+  "wednesday": 8,
+  "thursday": 8,
+  "friday": 6
+}


### PR DESCRIPTION
## Summary
- create `extension/work_schedule.json` for default work hours
- add options page in French to edit schedule stored in `chrome.storage.sync`
- localize popup and manifest text in French
- read user schedule in popup when computing progress

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684bef3cb0c88320b1229b0611dd7e8b